### PR TITLE
Avoid useLayoutEffect warning during SSR

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,8 @@ import {
     useMemo, 
     useCallback, 
     useRef, 
-    useLayoutEffect 
+    useLayoutEffect, 
+    useEffect, 
 } from 'react';
 
 function getVpWidth() {
@@ -19,6 +20,12 @@ function getVpHeight() {
         window.document.documentElement.clientHeight,
         window.innerHeight || 0
     ) : 0;
+}
+
+// Avoid useLayoutEffect warning during SSR
+// https://usehooks-ts.com/react-hook/use-isomorphic-layout-effect
+function useIsomorphicLayoutEffect() {
+    typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 }
 
 // =============== //
@@ -204,7 +211,7 @@ export default function useViewportSizes(input) {
         }
     }, [debounceTimeoutRef, hasher, dimension, state]);
 
-    useLayoutEffect(() => {
+    useIsomorphicLayoutEffect(() => {
         resolverMap.set(listener, {
             options,
             prevHash: state.hash || undefined


### PR DESCRIPTION
Add `useIsomorphicLayoutEffect` hook to suppress warning. Simply runs `useLayoutEffect` on client and `useEffect` on the server to silence the warning. There are no changes in behavior, since SSR will skip either hook. 

See https://usehooks-ts.com/react-hook/use-isomorphic-layout-effect for more details. You could import the hook but it's so small I figured it'd be simpler to just include it and avoid the dependency.